### PR TITLE
Fixed multiple Datatables with different breakpoints

### DIFF
--- a/files/1.10/js/datatables.responsive.js
+++ b/files/1.10/js/datatables.responsive.js
@@ -349,7 +349,7 @@ ResponsiveDatatablesHelper.prototype.respond = function () {
         });
     } else {
         this.tableElement.removeClass('has-columns-hidden');
-        $('tr.row-detail').each(function (event) {
+        $('tr.row-detail', this.tableElement).each(function (event) {
             ResponsiveDatatablesHelper.prototype.hideRowDetail(that, $(this).prev());
         });
     }
@@ -372,7 +372,7 @@ ResponsiveDatatablesHelper.prototype.showHideColumns = function () {
 
     // Rebuild details to reflect shown/hidden column changes.
     var that = this;
-    $('tr.row-detail').each(function () {
+    $('tr.row-detail', this.tableElement).each(function () {
         ResponsiveDatatablesHelper.prototype.hideRowDetail(that, $(this).prev());
     });
     if (this.tableElement.hasClass('has-columns-hidden')) {

--- a/files/1.9/js/datatables.responsive.js
+++ b/files/1.9/js/datatables.responsive.js
@@ -345,7 +345,7 @@ ResponsiveDatatablesHelper.prototype.respond = function () {
         });
     } else {
         this.tableElement.removeClass('has-columns-hidden');
-        $('tr.row-detail').each(function (event) {
+        $('tr.row-detail', this.tableElement).each(function (event) {
             ResponsiveDatatablesHelper.prototype.hideRowDetail(that, $(this).prev());
         });
     }
@@ -368,7 +368,7 @@ ResponsiveDatatablesHelper.prototype.showHideColumns = function () {
 
     // Rebuild details to reflect shown/hidden column changes.
     var that = this;
-    $('tr.row-detail').each(function () {
+    $('tr.row-detail', this.tableElement).each(function () {
         ResponsiveDatatablesHelper.prototype.hideRowDetail(that, $(this).prev());
     });
     if (this.tableElement.hasClass('has-columns-hidden')) {


### PR DESCRIPTION
Hi,


## Bug ##
There is a bug with the call of `hideRowDetail` in the `respond` prototype. Indeed when multiple DataTables with different breakpoints are defined and one DT trigger the responsive mode on a breakpoint (have hidden columns) and the other don't, the click on the [+] button show and hide directly after the `.rwo-detail`.
It is caused by the second DT (the one whitch don't have hidden columns). In the `respond` prototype, `hideRowDetail` will be call for each `tr.row-detail`. But the function only have to call on is own `tr.row-detail` => `tr.row-detail, this.tableElement`.

## Step to reproduce ##

- Define this breakpointDefinition :

    	var breakpointDefinition = {
            bigTab : 1790, // si écran < 1790, caché colonne
            tablet : 1024,
            phone : 480
        };

- Then define two tables (with **this**.responsiveHelper as described in [dom-bootstrap2-multiple-table.js](https://github.com/Comanche/datatables-responsive/blob/master/examples/dt1.9/js/dom-bootstrap2-multiple-table.js "dom-bootstrap2-multiple-table.js")). The first with `data-hide` on bigTab, tablet and phone and the second with `data-hide` only on tablet and phone.

![responinit](https://cloud.githubusercontent.com/assets/6648477/5802154/947a236e-9ff2-11e4-8133-5560ea681900.PNG)

- Resize the window with a width < 1790px and > 1024px. Then click on the [+] button. You should have this behavior :

![responsivebet](https://cloud.githubusercontent.com/assets/6648477/5802226/3d072932-9ff3-11e4-8a82-7c0a76cae215.PNG)

However when both datables trigger a berakpoint, it works.

![image](https://cloud.githubusercontent.com/assets/6648477/5802364/85371b8a-9ff4-11e4-9592-9203008f1eca.png)

Indeed as there are no hidden columns, the `hideRowDetail` is not call in `repond`.

This pull request fix this bug.



 